### PR TITLE
Fix compile error isnan

### DIFF
--- a/src/glimpse_context.cc
+++ b/src/glimpse_context.cc
@@ -995,9 +995,9 @@ reproject_cloud(const pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
         glm::vec3 point_t(point->x, point->y, point->z);
         glm::vec2 point_2d;
 
-        if (isnan(point->x) || isinf(point->x) ||
-            isnan(point->y) || isinf(point->y) ||
-            !isnormal(point->z) || point->z >= HUGE_DEPTH)
+        if (std::isnan(point->x) || std::isinf(point->x) ||
+            std::isnan(point->y) || std::isinf(point->y) ||
+            !std::isnormal(point->z) || point->z >= HUGE_DEPTH)
             continue;
 
         if (extrinsics) {
@@ -1317,7 +1317,7 @@ cluster2d(const pcl::PointCloud<pcl::PointXYZ>::Ptr cloud,
             int off = y * cloud->width + x;
             float depth = cloud->points[off].z;
 
-            if (isnan(depth)) {
+            if (std::isnan(depth)) {
                 continue;
             }
 
@@ -1492,7 +1492,7 @@ gm_context_track_skeleton(struct gm_context *ctx)
 
     foreach_xy_off(dense_cloud->width, dense_cloud->height) {
         float depth = tracking->depth[off];
-        if (isnormal(depth) &&
+        if (std::isnormal(depth) &&
             depth >= ctx->min_depth &&
             depth < ctx->max_depth) {
             float dx = (x - cx) * depth * inv_fx;
@@ -1516,7 +1516,7 @@ gm_context_track_skeleton(struct gm_context *ctx)
             ((y * ctx->seg_res * dense_cloud->width) + (x * ctx->seg_res));
         sparse_cloud->points[off] = dense_cloud->points[dense_off];
 
-        if (!isnan(sparse_cloud->points[off].z)) {
+        if (!std::isnan(sparse_cloud->points[off].z)) {
             ++n_sparse_points;
 
             // Only consider points below the camera to be the floor.
@@ -1669,7 +1669,7 @@ gm_context_track_skeleton(struct gm_context *ctx)
         }
 
         int off = y * ctx->depth_camera_intrinsics.width + x;
-        if (isnan(dense_cloud->points[off].z) ||
+        if (std::isnan(dense_cloud->points[off].z) ||
             fabsf(centroid[2] - dense_cloud->points[off].z) >
             centroid_tolerance) {
             continue;


### PR DESCRIPTION
Build fails in my machine with the following error: `'isnan’ was not declared in this scope` 

Not sure if this is the best solution but according with [this answer](https://stackoverflow.com/questions/18128899/is-isnan-in-the-std-namespace-more-in-general-when-is-std-necessary-optio), this should make it more portable.
